### PR TITLE
feat: implement configurable request retries

### DIFF
--- a/src/main/ac-api.ts
+++ b/src/main/ac-api.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Request, BasicAuthAgent, OAuth2Agent, RequestSpec, Response } from '@automationcloud/request';
+import { Request, BasicAuthAgent, OAuth2Agent, RequestSpec } from '@automationcloud/request';
 import { Logger } from './logger';
 import { ClientAuthParams, JobCategory, JobError, JobInputObject, JobState } from './types';
 
@@ -37,6 +37,9 @@ export class AcApi {
         this.request = new AcRequest({
             baseUrl: params.apiUrl,
             auth,
+            retryAttempts: params.requestRetryCount,
+            retryDelay: params.requestRetryDelay,
+            // Note: retryDelayIncrement stays the same to avoid unintentional DDoS
         });
     }
 
@@ -188,4 +191,6 @@ export interface AcApiParams {
     apiTokenUrl: string;
     auth: ClientAuthParams;
     logger: Logger;
+    requestRetryCount: number;
+    requestRetryDelay: number;
 }

--- a/src/main/client.ts
+++ b/src/main/client.ts
@@ -53,13 +53,17 @@ export class Client {
             apiTokenUrl: 'https://auth.automationcloud.net/auth/realms/automationcloud/protocol/openid-connect/token',
             vaultUrl: 'https://vault.automationcloud.net',
             pollInterval: 1000,
+            requestRetryCount: 4,
+            requestRetryDelay: 500,
             ...params,
         };
         this.api = new AcApi({
+            logger: this.logger,
             apiTokenUrl: this.config.apiTokenUrl,
             apiUrl: this.config.apiUrl,
             auth: this.config.auth,
-            logger: this.logger,
+            requestRetryCount: this.config.requestRetryCount,
+            requestRetryDelay: this.config.requestRetryDelay,
         });
         this.vault = new Vault(this);
     }

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -164,4 +164,12 @@ export interface ClientOptionalParams {
      * Poll interval in milliseconds for job state synchronization. Default: `1000` (1 second).
      */
     pollInterval: number;
+    /**
+     * The number of times failed http requests to Automation Cloud API will be resent in case of failure.
+     */
+    requestRetryCount: number;
+    /**
+     * The delay between re-sending the failed http requests.
+     */
+    requestRetryDelay: number;
 }

--- a/src/test/ac-mock.ts
+++ b/src/test/ac-mock.ts
@@ -14,7 +14,7 @@
 
 import * as http from 'http';
 import { AcJob, AcJobEvent, AcJobEventName, AcJobOutput, AcJobInput } from '../main/ac-api';
-import { Client, JobError, JobInputObject, JobState } from '../main';
+import { Client, ClientConfig, JobError, JobInputObject, JobState } from '../main';
 import Koa from 'koa';
 import Router from 'koa-router2';
 import bodyParser from 'koa-body';
@@ -58,7 +58,7 @@ export class AcMock extends EventEmitter {
                 ctx.body = {};
                 await next();
             } catch (err) {
-                ctx.status = 500;
+                ctx.status = err.status ?? 500;
                 ctx.body = {
                     name: err.name,
                     message: err.message,
@@ -80,13 +80,16 @@ export class AcMock extends EventEmitter {
         this.otp = null;
     }
 
-    createClient(): Client {
+    createClient(overrides: Partial<ClientConfig> = {}): Client {
         return new Client({
             serviceId: '123',
             auth: 'secret-key',
             pollInterval: 10,
             apiUrl: this.url,
-            vaultUrl: this.url + '/~vault'
+            vaultUrl: this.url + '/~vault',
+            requestRetryCount: 1,
+            requestRetryDelay: 50,
+            ...overrides,
         });
     }
 

--- a/src/test/specs/retries.test.ts
+++ b/src/test/specs/retries.test.ts
@@ -1,0 +1,77 @@
+import { AcMock } from '../ac-mock';
+import assert from 'assert';
+
+describe('Retry failed requests', () => {
+
+    const RECOVERABLE_ERROR_CODE = 502;
+    const UNRECOVERABLE_ERROR_CODE = 500;
+
+    context('request fails, then succeeds', () => {
+        const mock = new AcMock();
+        beforeEach(() => mock.start());
+        beforeEach(() => {
+            mock.on('createJob', () => {
+                mock.removeAllListeners('createJob');
+                const err: any = new Error('Boom');
+                err.status = RECOVERABLE_ERROR_CODE;
+                throw err;
+            });
+        });
+        afterEach(() => mock.stop());
+
+        it('retries and creates the job successfully', async () => {
+            const client = mock.createClient();
+            const job = await client.createJob();
+            mock.success();
+            await job.waitForCompletion();
+        });
+    });
+
+    context('request keeps failing', () => {
+        const mock = new AcMock();
+        beforeEach(() => mock.start());
+        beforeEach(() => {
+            mock.on('createJob', () => {
+                const err: any = new Error('Boom');
+                err.status = RECOVERABLE_ERROR_CODE;
+                throw err;
+            });
+        });
+        afterEach(() => mock.stop());
+
+        it('job create throws', async () => {
+            const client = mock.createClient();
+            try {
+                await client.createJob();
+                throw new Error('UnexpectedSuccess');
+            } catch (err) {
+                assert.strictEqual(err.message, 'Boom');
+            }
+        });
+    });
+
+    context('request fails with unrecoverable error', () => {
+        const mock = new AcMock();
+        beforeEach(() => mock.start());
+        beforeEach(() => {
+            mock.on('createJob', () => {
+                mock.removeAllListeners('createJob');
+                const err: any = new Error('Boom');
+                err.status = UNRECOVERABLE_ERROR_CODE;
+                throw err;
+            });
+        });
+        afterEach(() => mock.stop());
+
+        it('job create throws (does not retry)', async () => {
+            const client = mock.createClient();
+            try {
+                await client.createJob();
+                throw new Error('UnexpectedSuccess');
+            } catch (err) {
+                assert.strictEqual(err.message, 'Boom');
+            }
+        });
+    });
+
+});


### PR DESCRIPTION
This supersedes #6 in an attempt to avoid exposing parts of `request` interface.

Also see the tests that cover the exact expectations we have from this feature.