### PR TITLE
feat: add support for event:* outputs

### DIFF
--- a/src/main/errors.ts
+++ b/src/main/errors.ts
@@ -19,8 +19,6 @@ export class JobOutputWaitError extends Exception {
     }
 }
 
-export class JobWaitError extends Exception {}
-
 export class JobFailedError extends Exception {
 
     constructor(jobError: JobError | null) {

--- a/src/main/errors.ts
+++ b/src/main/errors.ts
@@ -13,11 +13,13 @@ export class JobAlreadyStartedError extends Exception {
     }
 }
 
-export class JobMissingOutputsError extends Exception {
+export class JobOutputWaitError extends Exception {
     constructor(public message: string, public details: any = {}) {
         super(message);
     }
 }
+
+export class JobWaitError extends Exception {}
 
 export class JobFailedError extends Exception {
 
@@ -33,7 +35,8 @@ export class JobFailedError extends Exception {
 }
 
 export class JobTrackError extends Exception {
-    constructor(public cause: Error) {
+    constructor(cause: Error) {
         super(`Job tracking failed: ${cause.message}`);
+        this.details = { cause };
     }
 }

--- a/src/main/job.ts
+++ b/src/main/job.ts
@@ -363,7 +363,7 @@ export class Job {
      */
     onDynamicOutput(keyPrefix: string, fn: (outputKey: string, outputData: any) => void | Promise<void>): JobEventHandler {
         return this._createJobEventHandler('output', async (output: JobOutput) => {
-            if (output.key.startsWith(keyPrefix + ':'), this._matchKey(keyPrefix, output.key)) {
+            if (output.key.startsWith(keyPrefix + ':') || this._matchKey(keyPrefix, output.key)) {
                 await fn(output.key, output.data);
             }
         });

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -110,6 +110,14 @@ export interface JobInputObject {
 }
 
 /**
+ * Output event produced by automation job.
+ */
+export interface JobOutputEvent {
+    eventType: string;
+    [key: string]: any;
+}
+
+/**
  * Event subscription methods like `onOutput` return handlers which can subsequently be invoked
  * with zero arguments to unsubscribe from the event.
  *

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -113,7 +113,7 @@ export interface JobInputObject {
  * Output event produced by automation job.
  */
 export interface JobOutputEvent {
-    eventType: string;
+    type: string;
     [key: string]: any;
 }
 

--- a/src/test/scenarios/price-consent.test.ts
+++ b/src/test/scenarios/price-consent.test.ts
@@ -90,9 +90,8 @@ describe('Scenario: Price Consent', () => {
                 await job.waitForCompletion();
                 throw new Error('UnexpectedSuccess');
             } catch (err) {
-                assert.strictEqual(err.name, 'JobOutputWaitError');
-                // assert.strictEqual(err.details.cause.name, 'JobTrackError');
-                // assert.strictEqual(err.details.cause.details.cause.name, 'BoomError');
+                assert.strictEqual(err.name, 'JobTrackError');
+                assert.strictEqual(err.details.cause.name, 'BoomError');
             }
         });
     });

--- a/src/test/scenarios/price-consent.test.ts
+++ b/src/test/scenarios/price-consent.test.ts
@@ -90,8 +90,9 @@ describe('Scenario: Price Consent', () => {
                 await job.waitForCompletion();
                 throw new Error('UnexpectedSuccess');
             } catch (err) {
-                assert.strictEqual(err.name, 'JobTrackError');
-                assert.strictEqual(err.cause.name, 'BoomError');
+                assert.strictEqual(err.name, 'JobOutputWaitError');
+                // assert.strictEqual(err.details.cause.name, 'JobTrackError');
+                // assert.strictEqual(err.details.cause.details.cause.name, 'BoomError');
             }
         });
     });

--- a/src/test/specs/events.test.ts
+++ b/src/test/specs/events.test.ts
@@ -168,4 +168,23 @@ describe('Events', () => {
         });
     });
 
+    describe('onOutputEvent', () => {
+
+        it('emits on output events', async () => {
+            let fooEvent: any = null;
+            let barEvent: any = null;
+            const client = mock.createClient();
+            const job = await client.createJob();
+            job.onOutputEvent('foo', ev => { fooEvent = ev; });
+            job.onOutputEvent('bar', ev => { barEvent = ev; });
+            mock.addOutput('events:1', { type: 'foo', foo: 'one' });
+            mock.addOutput('events:2', { type: 'bar', bar: 'two' });
+            mock.success();
+            await job.waitForCompletion();
+            assert.deepStrictEqual(fooEvent, { type: 'foo', foo: 'one' });
+            assert.deepStrictEqual(barEvent, { type: 'bar', bar: 'two' });
+        });
+
+    });
+
 });

--- a/src/test/specs/outputs.test.ts
+++ b/src/test/specs/outputs.test.ts
@@ -58,7 +58,7 @@ describe('Outputs', () => {
                     await job.waitForOutputs('someOutput', 'someOtherOutput');
                     throw new Error();
                 } catch (err) {
-                    assert.strictEqual(err.name, 'JobMissingOutputsError');
+                    assert.strictEqual(err.name, 'JobOutputWaitError');
                 }
             });
         });
@@ -72,10 +72,11 @@ describe('Outputs', () => {
                     await job.waitForOutputs('someOutput');
                     throw new Error();
                 } catch (err) {
-                    assert.strictEqual(err.name, 'JobMissingOutputsError');
+                    assert.strictEqual(err.name, 'JobOutputWaitError');
                 }
             });
         });
+
     });
 
     describe('getOutput', () => {


### PR DESCRIPTION
Automation jobs will be able to emit events as `event:*` outputs. JavaScript client will provide first-class support for those with dedicated methods.

The functionality is tagged `beta` so we should track the usage of those and update should we decide to introduce incompatible changes.